### PR TITLE
Secure API configuration via plist and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Xcode build and user files
+DerivedData/
+build/
+
+# Sensitive configuration
+Config.plist
+.env
+
+# macOS
+.DS_Store

--- a/Config.plist.example
+++ b/Config.plist.example
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>OPENAI_API_KEY</key>
+    <string>YOUR_OPENAI_API_KEY</string>
+    <key>WHISPER_API_KEY</key>
+    <string>YOUR_WHISPER_API_KEY</string>
+    <key>FIREBASE_CONFIG</key>
+    <string>YOUR_FIREBASE_CONFIG</string>
+    <key>REVENUECAT_KEY</key>
+    <string>YOUR_REVENUECAT_KEY</string>
+</dict>
+</plist>

--- a/ConfigManager.swift
+++ b/ConfigManager.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+final class ConfigManager {
+    static let shared = ConfigManager()
+    private var config: [String: Any] = [:]
+
+    private init() {
+        if let url = Bundle.main.url(forResource: "Config", withExtension: "plist"),
+           let data = try? Data(contentsOf: url),
+           let dict = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any] {
+            config = dict
+        } else {
+            print("⚠️ Config.plist not found or unreadable")
+        }
+    }
+
+    func stringValue(for key: String) -> String {
+        config[key] as? String ?? ""
+    }
+}

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ import CoreML
 
 1. Open the project in Xcode 15+
 2. Configure signing and capabilities
-3. Add required API keys for AI services
+3. Copy `Config.plist.example` to `Config.plist` and add your API keys
 4. Build and run on iOS 16+ device or simulator
 
 ## API Integration
@@ -110,13 +110,15 @@ import CoreML
 - **Firebase**: For user authentication and analytics
 - **RevenueCat**: For subscription management
 
-### Environment Variables
-```swift
-// Add to Info.plist or environment
-OPENAI_API_KEY = "your_openai_key"
-FIREBASE_CONFIG = "your_firebase_config"
-REVENUECAT_KEY = "your_revenuecat_key"
-```
+### Configuration
+
+Create a `Config.plist` file (ignored by git) using `Config.plist.example` as a template and provide the following keys:
+
+- `OPENAI_API_KEY`
+- `WHISPER_API_KEY`
+- `FIREBASE_CONFIG`
+- `REVENUECAT_KEY`
+
 
 ## Target Market
 

--- a/SnapEditAIApp.swift
+++ b/SnapEditAIApp.swift
@@ -3,7 +3,7 @@ import SwiftUI
 @main
 struct SnapEditAIApp: App {
     @StateObject private var appState = AppState()
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
@@ -18,13 +18,27 @@ class AppState: ObservableObject {
     @Published var isPremiumUser = false
     @Published var currentProject: VideoProject?
     @Published var exportCount = 0
-    
+
     let maxFreeExports = 3
-    
+
+    // API keys loaded from secure Config.plist
+    let openAIKey: String
+    let whisperKey: String
+    let firebaseConfig: String
+    let revenueCatKey: String
+
+    init() {
+        let config = ConfigManager.shared
+        openAIKey = config.stringValue(for: "OPENAI_API_KEY")
+        whisperKey = config.stringValue(for: "WHISPER_API_KEY")
+        firebaseConfig = config.stringValue(for: "FIREBASE_CONFIG")
+        revenueCatKey = config.stringValue(for: "REVENUECAT_KEY")
+    }
+
     var canExport: Bool {
         isPremiumUser || exportCount < maxFreeExports
     }
-    
+
     func incrementExportCount() {
         if !isPremiumUser {
             exportCount += 1
@@ -54,7 +68,7 @@ enum CaptionStyle: String, CaseIterable {
     case minimal = "Minimal"
     case podcast = "Podcast"
     case storytime = "Storytime"
-    
+
     var emoji: String {
         switch self {
         case .viral: return "🔥"
@@ -78,4 +92,3 @@ enum EffectType: String, CaseIterable {
     case overlay = "Overlay"
     case animation = "Animation"
 }
-


### PR DESCRIPTION
## Summary
- centralize API credentials in `Config.plist` loaded through new `ConfigManager`
- document setup flow and provide `Config.plist.example`
- ignore `Config.plist` and environment files in version control

## Testing
- `swift build` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_688d7ff730a48329b6b57ebdcee9f70d