### PR TITLE
Add persistence for app state and projects

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -152,8 +152,8 @@ struct HomeView: View {
                         
                         ScrollView(.horizontal, showsIndicators: false) {
                             HStack(spacing: 12) {
-                                ForEach(0..<5) { index in
-                                    ProjectCard(index: index)
+                                ForEach(appState.projects) { project in
+                                    ProjectCard(project: project)
                                 }
                             }
                             .padding(.horizontal)
@@ -205,8 +205,8 @@ struct QuickActionCard: View {
 }
 
 struct ProjectCard: View {
-    let index: Int
-    
+    let project: VideoProject
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             RoundedRectangle(cornerRadius: 8)
@@ -217,13 +217,13 @@ struct ProjectCard: View {
                         .font(.title)
                         .foregroundColor(.white)
                 )
-            
-            Text("Video \(index + 1)")
+
+            Text(project.title)
                 .font(.caption)
                 .fontWeight(.medium)
                 .foregroundColor(.white)
-            
-            Text("2 days ago")
+
+            Text(project.createdAt, style: .date)
                 .font(.caption2)
                 .foregroundColor(.gray)
         }

--- a/EditorView.swift
+++ b/EditorView.swift
@@ -4,7 +4,6 @@ import AVFoundation
 struct EditorView: View {
     @EnvironmentObject var appState: AppState
     @State private var showingVideoPicker = false
-    @State private var currentProject: VideoProject?
     @State private var isPlaying = false
     @State private var currentTime: Double = 0
     @State private var duration: Double = 100
@@ -13,7 +12,7 @@ struct EditorView: View {
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
-                if let project = currentProject {
+                if let project = appState.currentProject {
                     // Video Preview
                     VideoPreviewSection(
                         project: project,
@@ -65,8 +64,8 @@ struct EditorView: View {
             title: "New Video \(Date().formatted(.dateTime.hour().minute()))",
             videoURL: videoURL
         )
-        currentProject = project
         appState.currentProject = project
+        appState.projects.append(project)
     }
 }
 

--- a/Persistence/PersistenceManager.swift
+++ b/Persistence/PersistenceManager.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+final class PersistenceManager {
+    static let shared = PersistenceManager()
+    private init() {}
+
+    private let defaults = UserDefaults.standard
+    private let exportCountKey = "exportCount"
+    private let isPremiumUserKey = "isPremiumUser"
+    private let projectsKey = "projects"
+
+    func saveAppState(exportCount: Int, isPremiumUser: Bool, projects: [VideoProject]) {
+        defaults.set(exportCount, forKey: exportCountKey)
+        defaults.set(isPremiumUser, forKey: isPremiumUserKey)
+        if let data = try? JSONEncoder().encode(projects) {
+            defaults.set(data, forKey: projectsKey)
+        }
+    }
+
+    func loadAppState() -> (exportCount: Int, isPremiumUser: Bool, projects: [VideoProject]) {
+        let exportCount = defaults.integer(forKey: exportCountKey)
+        let isPremiumUser = defaults.bool(forKey: isPremiumUserKey)
+        var projects: [VideoProject] = []
+        if let data = defaults.data(forKey: projectsKey),
+           let decoded = try? JSONDecoder().decode([VideoProject].self, from: data) {
+            projects = decoded
+        }
+        return (exportCount, isPremiumUser, projects)
+    }
+}
+

--- a/SnapEditAIApp.swift
+++ b/SnapEditAIApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Foundation
 
 @main
 struct SnapEditAIApp: App {
@@ -14,17 +15,37 @@ struct SnapEditAIApp: App {
 }
 
 class AppState: ObservableObject {
+    private let persistence = PersistenceManager.shared
+
     @Published var isOnboardingComplete = false
-    @Published var isPremiumUser = false
+    @Published var isPremiumUser: Bool = false {
+        didSet { saveState() }
+    }
     @Published var currentProject: VideoProject?
-    @Published var exportCount = 0
-    
+    @Published var exportCount: Int = 0 {
+        didSet { saveState() }
+    }
+    @Published var projects: [VideoProject] = [] {
+        didSet { saveState() }
+    }
+
     let maxFreeExports = 3
-    
+
     var canExport: Bool {
         isPremiumUser || exportCount < maxFreeExports
     }
-    
+
+    init() {
+        let loaded = persistence.loadAppState()
+        self.exportCount = loaded.exportCount
+        self.isPremiumUser = loaded.isPremiumUser
+        self.projects = loaded.projects
+    }
+
+    private func saveState() {
+        persistence.saveAppState(exportCount: exportCount, isPremiumUser: isPremiumUser, projects: projects)
+    }
+
     func incrementExportCount() {
         if !isPremiumUser {
             exportCount += 1
@@ -32,29 +53,46 @@ class AppState: ObservableObject {
     }
 }
 
-struct VideoProject: Identifiable {
-    let id = UUID()
+struct VideoProject: Identifiable, Codable {
+    let id: UUID
     var title: String
     var videoURL: URL?
     var captions: [Caption] = []
     var effects: [VideoEffect] = []
-    var createdAt = Date()
+    var createdAt: Date = Date()
+
+    init(id: UUID = UUID(), title: String, videoURL: URL? = nil, captions: [Caption] = [], effects: [VideoEffect] = [], createdAt: Date = Date()) {
+        self.id = id
+        self.title = title
+        self.videoURL = videoURL
+        self.captions = captions
+        self.effects = effects
+        self.createdAt = createdAt
+    }
 }
 
-struct Caption: Identifiable {
-    let id = UUID()
+struct Caption: Identifiable, Codable {
+    let id: UUID
     var text: String
     var startTime: Double
     var endTime: Double
     var style: CaptionStyle = .viral
+
+    init(id: UUID = UUID(), text: String, startTime: Double, endTime: Double, style: CaptionStyle = .viral) {
+        self.id = id
+        self.text = text
+        self.startTime = startTime
+        self.endTime = endTime
+        self.style = style
+    }
 }
 
-enum CaptionStyle: String, CaseIterable {
+enum CaptionStyle: String, CaseIterable, Codable {
     case viral = "Viral"
     case minimal = "Minimal"
     case podcast = "Podcast"
     case storytime = "Storytime"
-    
+
     var emoji: String {
         switch self {
         case .viral: return "🔥"
@@ -65,14 +103,21 @@ enum CaptionStyle: String, CaseIterable {
     }
 }
 
-struct VideoEffect: Identifiable {
-    let id = UUID()
+struct VideoEffect: Identifiable, Codable {
+    let id: UUID
     var name: String
     var type: EffectType
     var intensity: Double = 1.0
+
+    init(id: UUID = UUID(), name: String, type: EffectType, intensity: Double = 1.0) {
+        self.id = id
+        self.name = name
+        self.type = type
+        self.intensity = intensity
+    }
 }
 
-enum EffectType: String, CaseIterable {
+enum EffectType: String, CaseIterable, Codable {
     case transition = "Transition"
     case filter = "Filter"
     case overlay = "Overlay"

--- a/SupportingViews.swift
+++ b/SupportingViews.swift
@@ -302,7 +302,7 @@ struct ProfileView: View {
                         ProfileMenuItem(
                             icon: "video.fill",
                             title: "My Projects",
-                            subtitle: "View all your videos"
+                            subtitle: "\(appState.projects.count) videos"
                         )
                         
                         ProfileMenuItem(


### PR DESCRIPTION
## Summary
- add PersistenceManager using UserDefaults to store export count, premium status, and projects
- load and save persistent values through AppState
- display saved projects in UI and update Editor and Profile views to use persistent data

## Testing
- `swiftc SnapEditAIApp.swift ContentView.swift EditorView.swift SupportingViews.swift OnboardingView.swift Persistence/PersistenceManager.swift -parse-as-library` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_688d7fdb154483299b1e3cfa7d66b183