### PR TITLE
Refactor views into view models and add tests

### DIFF
--- a/EditorView.swift
+++ b/EditorView.swift
@@ -3,42 +3,37 @@ import AVFoundation
 
 struct EditorView: View {
     @EnvironmentObject var appState: AppState
-    @State private var showingVideoPicker = false
-    @State private var currentProject: VideoProject?
-    @State private var isPlaying = false
-    @State private var currentTime: Double = 0
-    @State private var duration: Double = 100
-    @State private var selectedTool: EditorTool = .trim
+    @StateObject private var viewModel = EditorViewModel()
     
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
-                if let project = currentProject {
+                if let project = viewModel.currentProject {
                     // Video Preview
                     VideoPreviewSection(
                         project: project,
-                        isPlaying: $isPlaying,
-                        currentTime: $currentTime,
-                        duration: $duration
+                        isPlaying: $viewModel.isPlaying,
+                        currentTime: $viewModel.currentTime,
+                        duration: $viewModel.duration
                     )
                     
                     // Timeline
                     TimelineSection(
-                        currentTime: $currentTime,
-                        duration: duration,
+                        currentTime: $viewModel.currentTime,
+                        duration: viewModel.duration,
                         project: project
                     )
                     
                     // Tools Section
                     ToolsSection(
-                        selectedTool: $selectedTool,
+                        selectedTool: $viewModel.selectedTool,
                         project: project
                     )
                     
                     // Bottom Actions
-                    BottomActionsSection(project: project)
+                    BottomActionsSection(project: project, viewModel: viewModel)
                 } else {
-                    EmptyEditorState(showingVideoPicker: $showingVideoPicker)
+                    EmptyEditorState(showingVideoPicker: $viewModel.showingVideoPicker)
                 }
             }
             .background(Color.black)
@@ -47,26 +42,22 @@ struct EditorView: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Import") {
-                        showingVideoPicker = true
+                        viewModel.showingVideoPicker = true
                     }
                     .foregroundColor(.purple)
                 }
             }
         }
-        .sheet(isPresented: $showingVideoPicker) {
+        .sheet(isPresented: $viewModel.showingVideoPicker) {
             VideoPickerView { url in
-                createNewProject(with: url)
+                viewModel.createNewProject(with: url, appState: appState)
             }
         }
-    }
-    
-    private func createNewProject(with videoURL: URL) {
-        let project = VideoProject(
-            title: "New Video \(Date().formatted(.dateTime.hour().minute()))",
-            videoURL: videoURL
-        )
-        currentProject = project
-        appState.currentProject = project
+        .sheet(isPresented: $viewModel.showingExportOptions) {
+            if let project = viewModel.currentProject {
+                ExportOptionsView(project: project)
+            }
+        }
     }
 }
 
@@ -430,23 +421,19 @@ struct AudioToolView: View {
 struct BottomActionsSection: View {
     let project: VideoProject
     @EnvironmentObject var appState: AppState
-    @State private var showingExportOptions = false
-    
+    @ObservedObject var viewModel: EditorViewModel
+
     var body: some View {
         HStack(spacing: 16) {
             Button("Preview") {
                 // Preview video
             }
             .buttonStyle(SecondaryActionButtonStyle())
-            
+
             Spacer()
-            
+
             Button("Export") {
-                if appState.canExport {
-                    showingExportOptions = true
-                } else {
-                    // Show upgrade prompt
-                }
+                viewModel.export(appState: appState)
             }
             .buttonStyle(PrimaryActionButtonStyle())
             .disabled(!appState.canExport)
@@ -454,9 +441,6 @@ struct BottomActionsSection: View {
         .padding(.horizontal)
         .padding(.vertical, 16)
         .background(Color.black)
-        .sheet(isPresented: $showingExportOptions) {
-            ExportOptionsView(project: project)
-        }
     }
 }
 

--- a/EditorViewModel.swift
+++ b/EditorViewModel.swift
@@ -1,0 +1,30 @@
+import Foundation
+#if canImport(Combine)
+import Combine
+#endif
+
+@MainActor
+class EditorViewModel: ObservableObject {
+    @Published var showingVideoPicker = false
+    @Published var currentProject: VideoProject?
+    @Published var isPlaying = false
+    @Published var currentTime: Double = 0
+    @Published var duration: Double = 100
+    @Published var selectedTool: EditorTool = .trim
+    @Published var showingExportOptions = false
+
+    func createNewProject(with videoURL: URL, appState: AppState) {
+        let project = VideoProject(
+            title: "New Video \(Date().formatted(.dateTime.hour().minute()))",
+            videoURL: videoURL
+        )
+        currentProject = project
+        appState.currentProject = project
+    }
+
+    func export(appState: AppState) {
+        if appState.canExport {
+            showingExportOptions = true
+        }
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,43 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "SnapEditAI",
+    platforms: [
+        .iOS(.v16)
+    ],
+    products: [
+        .library(name: "SnapEditAI", targets: ["SnapEditAI"])
+    ],
+    targets: [
+        .target(
+            name: "SnapEditAI",
+            path: ".",
+            exclude: [
+                "README.md",
+                "todo.md",
+                "pasted_content.txt",
+                "SnapEditAI_Complete_Project.zip",
+                "SnapEdit AI - Complete Project Deliverables.md",
+                "SnapEdit AI: AI-Powered Video Editor for Short-Form Content.pptx",
+                "Tests",
+                ".git",
+                ".DS_Store"
+            ],
+            sources: [
+                "ContentView.swift",
+                "EditorView.swift",
+                "OnboardingView.swift",
+                "SnapEditAIApp.swift",
+                "SupportingViews.swift",
+                "EditorViewModel.swift",
+                "TemplatesViewModel.swift"
+            ]
+        ),
+        .testTarget(
+            name: "SnapEditAITests",
+            dependencies: ["SnapEditAI"],
+            path: "Tests"
+        )
+    ]
+)

--- a/SupportingViews.swift
+++ b/SupportingViews.swift
@@ -109,17 +109,8 @@ struct ImportOptionCard: View {
 }
 
 struct TemplatesView: View {
-    @State private var selectedCategory: TemplateCategory = .trending
-    
-    let templates = [
-        Template(name: "Viral Hook", category: .trending, thumbnail: "play.rectangle.fill"),
-        Template(name: "Storytime", category: .trending, thumbnail: "text.bubble.fill"),
-        Template(name: "Tutorial", category: .educational, thumbnail: "graduationcap.fill"),
-        Template(name: "Product Review", category: .business, thumbnail: "star.fill"),
-        Template(name: "GRWM", category: .lifestyle, thumbnail: "person.fill"),
-        Template(name: "Recipe", category: .lifestyle, thumbnail: "fork.knife"),
-    ]
-    
+    @StateObject private var viewModel = TemplatesViewModel()
+
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
@@ -129,9 +120,9 @@ struct TemplatesView: View {
                         ForEach(TemplateCategory.allCases, id: \.self) { category in
                             CategoryButton(
                                 category: category,
-                                isSelected: selectedCategory == category
+                                isSelected: viewModel.selectedCategory == category
                             ) {
-                                selectedCategory = category
+                                viewModel.selectedCategory = category
                             }
                         }
                     }
@@ -139,14 +130,14 @@ struct TemplatesView: View {
                 }
                 .padding(.vertical)
                 .background(Color.gray.opacity(0.05))
-                
+
                 // Templates Grid
                 ScrollView {
                     LazyVGrid(columns: [
                         GridItem(.flexible()),
                         GridItem(.flexible())
                     ], spacing: 16) {
-                        ForEach(filteredTemplates) { template in
+                        ForEach(viewModel.filteredTemplates) { template in
                             TemplateCard(template: template)
                         }
                     }
@@ -157,10 +148,6 @@ struct TemplatesView: View {
             .navigationTitle("Templates")
             .navigationBarTitleDisplayMode(.large)
         }
-    }
-    
-    var filteredTemplates: [Template] {
-        templates.filter { $0.category == selectedCategory }
     }
 }
 

--- a/TemplatesViewModel.swift
+++ b/TemplatesViewModel.swift
@@ -1,0 +1,28 @@
+import Foundation
+#if canImport(Combine)
+import Combine
+#endif
+
+class TemplatesViewModel: ObservableObject {
+    @Published var selectedCategory: TemplateCategory = .trending
+    @Published var templates: [Template]
+
+    init(templates: [Template] = [
+        Template(name: "Viral Hook", category: .trending, thumbnail: "play.rectangle.fill"),
+        Template(name: "Storytime", category: .trending, thumbnail: "text.bubble.fill"),
+        Template(name: "Tutorial", category: .educational, thumbnail: "graduationcap.fill"),
+        Template(name: "Product Review", category: .business, thumbnail: "star.fill"),
+        Template(name: "GRWM", category: .lifestyle, thumbnail: "person.fill"),
+        Template(name: "Recipe", category: .lifestyle, thumbnail: "fork.knife")
+    ]) {
+        self.templates = templates
+    }
+
+    var filteredTemplates: [Template] {
+        templates.filter { $0.category == selectedCategory }
+    }
+
+    func fetchTemplates() {
+        // Placeholder for API call to fetch templates
+    }
+}

--- a/Tests/EditorViewModelTests.swift
+++ b/Tests/EditorViewModelTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import SnapEditAI
+
+final class EditorViewModelTests: XCTestCase {
+    func testCreateNewProjectSetsProject() {
+        let appState = AppState()
+        let vm = EditorViewModel()
+        let url = URL(fileURLWithPath: "/tmp/video.mp4")
+        vm.createNewProject(with: url, appState: appState)
+        XCTAssertEqual(vm.currentProject?.videoURL, url)
+        XCTAssertEqual(appState.currentProject?.videoURL, url)
+    }
+
+    func testExportUpdatesStateWhenAllowed() {
+        let appState = AppState()
+        appState.isPremiumUser = true
+        let vm = EditorViewModel()
+        vm.export(appState: appState)
+        XCTAssertTrue(vm.showingExportOptions)
+    }
+}

--- a/Tests/TemplatesViewModelTests.swift
+++ b/Tests/TemplatesViewModelTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import SnapEditAI
+
+final class TemplatesViewModelTests: XCTestCase {
+    func testFilteredTemplatesMatchCategory() {
+        let vm = TemplatesViewModel()
+        vm.selectedCategory = .business
+        XCTAssertTrue(vm.filteredTemplates.allSatisfy { $0.category == .business })
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `EditorViewModel` to manage editor state and export actions
- Introduce `TemplatesViewModel` for category selection and template filtering
- Bind `EditorView` and `TemplatesView` to their view models using `@StateObject`
- Add unit tests for both view models and Swift Package manifest

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_688d7fffe2fc83298f821f7dede3d2e3