### PR TITLE
feat: implement video picker with camera and library

### DIFF
--- a/SupportingViews.swift
+++ b/SupportingViews.swift
@@ -1,10 +1,18 @@
 import SwiftUI
 import PhotosUI
+import AVFoundation
+import Photos
 
 struct VideoPickerView: View {
     @Environment(\.dismiss) private var dismiss
     var onVideoSelected: ((URL) -> Void)?
-    
+
+    @State private var showingCamera = false
+    @State private var showingLibrary = false
+    @State private var selectedItem: PhotosPickerItem?
+    @State private var showingError = false
+    @State private var errorMessage = ""
+
     var body: some View {
         NavigationView {
             VStack(spacing: 20) {
@@ -12,7 +20,7 @@ struct VideoPickerView: View {
                     .font(.largeTitle)
                     .fontWeight(.bold)
                     .foregroundColor(.white)
-                
+
                 VStack(spacing: 16) {
                     ImportOptionCard(
                         icon: "camera.fill",
@@ -20,35 +28,20 @@ struct VideoPickerView: View {
                         subtitle: "Capture video with camera",
                         color: .red
                     ) {
-                        // Open camera
-                        dismiss()
+                        handleCameraSelection()
                     }
-                    
+
                     ImportOptionCard(
                         icon: "photo.on.rectangle",
                         title: "Photo Library",
                         subtitle: "Choose from your videos",
                         color: .blue
                     ) {
-                        // Open photo library
-                        if let url = URL(string: "sample_video.mp4") {
-                            onVideoSelected?(url)
-                        }
-                        dismiss()
-                    }
-                    
-                    ImportOptionCard(
-                        icon: "icloud.and.arrow.down",
-                        title: "iCloud Drive",
-                        subtitle: "Import from cloud storage",
-                        color: .green
-                    ) {
-                        // Open iCloud picker
-                        dismiss()
+                        handleLibrarySelection()
                     }
                 }
                 .padding(.horizontal)
-                
+
                 Spacer()
             }
             .padding()
@@ -62,6 +55,80 @@ struct VideoPickerView: View {
                     .foregroundColor(.white)
                 }
             }
+            .photosPicker(isPresented: $showingLibrary, selection: $selectedItem, matching: .videos)
+            .sheet(isPresented: $showingCamera) {
+                CameraCaptureView { url in
+                    onVideoSelected?(url)
+                    dismiss()
+                }
+            }
+            .onChange(of: selectedItem) { _ in
+                Task { await loadSelectedItem() }
+            }
+            .alert("Permission Error", isPresented: $showingError) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(errorMessage)
+            }
+        }
+    }
+
+    private func handleLibrarySelection() {
+        let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        switch status {
+        case .authorized, .limited:
+            showingLibrary = true
+        case .notDetermined:
+            PHPhotoLibrary.requestAuthorization(for: .readWrite) { newStatus in
+                DispatchQueue.main.async {
+                    if newStatus == .authorized || newStatus == .limited {
+                        showingLibrary = true
+                    } else {
+                        errorMessage = "Photo library access denied"
+                        showingError = true
+                    }
+                }
+            }
+        default:
+            errorMessage = "Photo library access denied"
+            showingError = true
+        }
+    }
+
+    private func handleCameraSelection() {
+        let status = AVCaptureDevice.authorizationStatus(for: .video)
+        switch status {
+        case .authorized:
+            showingCamera = true
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                DispatchQueue.main.async {
+                    if granted {
+                        showingCamera = true
+                    } else {
+                        errorMessage = "Camera access denied"
+                        showingError = true
+                    }
+                }
+            }
+        default:
+            errorMessage = "Camera access denied"
+            showingError = true
+        }
+    }
+
+    private func loadSelectedItem() async {
+        guard let item = selectedItem else { return }
+        do {
+            if let data = try await item.loadTransferable(type: Data.self) {
+                let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).mov")
+                try data.write(to: tempURL)
+                onVideoSelected?(tempURL)
+                dismiss()
+            }
+        } catch {
+            errorMessage = "Failed to load video"
+            showingError = true
         }
     }
 }
@@ -106,6 +173,104 @@ struct ImportOptionCard: View {
             .cornerRadius(12)
         }
     }
+}
+
+struct CameraCaptureView: View {
+    @Environment(\.dismiss) private var dismiss
+    var onVideoCaptured: (URL) -> Void
+    @StateObject private var recorder = CameraRecorder()
+
+    var body: some View {
+        ZStack {
+            CameraPreview(session: recorder.session)
+                .ignoresSafeArea()
+
+            VStack {
+                Spacer()
+
+                Button(action: {
+                    if recorder.isRecording {
+                        recorder.stopRecording()
+                    } else {
+                        recorder.startRecording()
+                    }
+                }) {
+                    Circle()
+                        .fill(recorder.isRecording ? Color.red : Color.white)
+                        .frame(width: 70, height: 70)
+                        .overlay(Circle().stroke(Color.white, lineWidth: 2))
+                }
+                .padding(.bottom, 30)
+            }
+        }
+        .onAppear {
+            recorder.onFinish = { url in
+                onVideoCaptured(url)
+                dismiss()
+            }
+            recorder.configure()
+        }
+        .onDisappear {
+            recorder.stopSession()
+        }
+    }
+}
+
+final class CameraRecorder: NSObject, ObservableObject, AVCaptureFileOutputRecordingDelegate {
+    let session = AVCaptureSession()
+    private let output = AVCaptureMovieFileOutput()
+    @Published var isRecording = false
+    var onFinish: ((URL) -> Void)?
+
+    func configure() {
+        session.beginConfiguration()
+        if let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back),
+           let input = try? AVCaptureDeviceInput(device: device),
+           session.canAddInput(input) {
+            session.addInput(input)
+        }
+        if session.canAddOutput(output) {
+            session.addOutput(output)
+        }
+        session.commitConfiguration()
+        session.startRunning()
+    }
+
+    func startRecording() {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).mov")
+        output.startRecording(to: url, recordingDelegate: self)
+        isRecording = true
+    }
+
+    func stopRecording() {
+        output.stopRecording()
+    }
+
+    func stopSession() {
+        session.stopRunning()
+    }
+
+    func fileOutput(_ output: AVCaptureFileOutput, didFinishRecordingTo outputFileURL: URL, from connections: [AVCaptureConnection], error: Error?) {
+        isRecording = false
+        if error == nil {
+            onFinish?(outputFileURL)
+        }
+    }
+}
+
+struct CameraPreview: UIViewRepresentable {
+    let session: AVCaptureSession
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView(frame: .zero)
+        let layer = AVCaptureVideoPreviewLayer(session: session)
+        layer.videoGravity = .resizeAspectFill
+        layer.frame = UIScreen.main.bounds
+        view.layer.addSublayer(layer)
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
 }
 
 struct TemplatesView: View {


### PR DESCRIPTION
## Summary
- replace placeholder video picker with working photo library and camera options
- pass selected or recorded video URL back to editor via onVideoSelected
- handle permission errors for camera and photo library

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_688e4add867c8329b4f1c3ea6fc998c7