### PR TITLE
Use secure configuration files for API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Xcode build and user files
 DerivedData/
 build/
+.build/
 
 # Sensitive configuration
 Config.plist

--- a/Config.plist.example
+++ b/Config.plist.example
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Sample configuration file. Copy to Config.plist and provide your own keys. -->
 <plist version="1.0">
 <dict>
     <key>OPENAI_API_KEY</key>

--- a/ConfigManager.swift
+++ b/ConfigManager.swift
@@ -1,20 +1,47 @@
 import Foundation
 
+/// Loads configuration values from `Config.plist`, a local `.env` file, or
+/// environment variables. Values loaded later override earlier ones, giving
+/// precedence to environment variables for secure overrides.
 final class ConfigManager {
     static let shared = ConfigManager()
-    private var config: [String: Any] = [:]
+    private var config: [String: String] = [:]
 
     private init() {
+        // 1. Load from bundled Config.plist if it exists
         if let url = Bundle.main.url(forResource: "Config", withExtension: "plist"),
            let data = try? Data(contentsOf: url),
            let dict = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any] {
-            config = dict
+            for (key, value) in dict {
+                if let stringValue = value as? String {
+                    config[key] = stringValue
+                }
+            }
         } else {
             print("⚠️ Config.plist not found or unreadable")
         }
+
+        // 2. Merge values from a local .env file if present
+        if let envURL = Bundle.main.url(forResource: ".env", withExtension: nil),
+           let contents = try? String(contentsOf: envURL) {
+            let lines = contents.split(whereSeparator: \.isNewline)
+            for line in lines {
+                let parts = line.split(separator: "=", maxSplits: 1).map { String($0).trimmingCharacters(in: .whitespaces) }
+                if parts.count == 2 {
+                    config[parts[0]] = parts[1]
+                }
+            }
+        }
+
+        // 3. Override with environment variables
+        for (key, value) in ProcessInfo.processInfo.environment {
+            config[key] = value
+        }
     }
 
+    /// Returns the configuration value for the given key or an empty string if
+    /// the key is not found.
     func stringValue(for key: String) -> String {
-        config[key] as? String ?? ""
+        config[key] ?? ""
     }
 }

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ import CoreML
 
 1. Open the project in Xcode 15+
 2. Configure signing and capabilities
-3. Copy `Config.plist.example` to `Config.plist` and add your API keys
+3. Copy `Config.plist.example` to `Config.plist` and add your API keys, **or** create a `.env` file with the same keys.
 4. Build and run on iOS 16+ device or simulator
 
 ## API Integration
@@ -112,7 +112,12 @@ import CoreML
 
 ### Configuration
 
-Create a `Config.plist` file (ignored by git) using `Config.plist.example` as a template and provide the following keys:
+API credentials are never committed to the repository. The app reads values from `Config.plist`, an optional `.env` file, or environment variables in that order.
+
+1. Copy `Config.plist.example` to `Config.plist` and supply your own values, **or**
+2. Create a `.env` file (also ignored by git) with the following keys.
+
+Required keys:
 
 - `OPENAI_API_KEY`
 - `WHISPER_API_KEY`


### PR DESCRIPTION
## Summary
- load API credentials from Config.plist, .env, or environment variables
- document configuration steps in README
- provide sample Config.plist example
- ignore SwiftPM build artifacts

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_688e4ae676cc8329a6d019e2edb9d8db